### PR TITLE
implementando hadolint para cuidar da dockerfile do projeto

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,22 @@
+name: Hadolint Dockerfile Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Run Hadolint
+      uses: docker://ghcr.io/hadolint/hadolint
+      with:
+        args: "Dockerfile"


### PR DESCRIPTION
Neste pr implementei o hadolint, um lint para o docker. 

### O que é o Hadolint?
O Hadolint é uma ferramenta de análise estática para Dockerfiles que ajuda a identificar possíveis erros e más práticas na construção de contêineres Docker. Ele é muito útil para garantir que seus Dockerfiles sigam as melhores práticas e padrões de segurança.

### Hadolint no GitHub Actions
Com essa configuração, o Hadolint será executado automaticamente neste repositório GitHub, ajudando a manter a qualidade dos seus Dockerfiles ao longo do tempo. Essa integração facilita a detecção precoce de problemas e incentiva boas práticas em suas imagens Docker. 